### PR TITLE
Add vim modeline to conf

### DIFF
--- a/misc/Config Directory/homematicbidcos.conf
+++ b/misc/Config Directory/homematicbidcos.conf
@@ -260,3 +260,5 @@ processBroadcastWithAesEnabled = false
 ## - Without high gain mode: 0xC2
 ## - With high gain mode: 0x27 (maximum legally allowed setting)
 #txPowerSetting = 0x27
+
+# vim: filetype=cfg


### PR DESCRIPTION
This vim modeline will make vim color highlight the configuration file. Not more, not less.
The same line could be added to all other conf's. 
