### PR TITLE
Filter for 'ls' should handle case and also find parts of hex strings

### DIFF
--- a/src/HomeMaticCentral.cpp
+++ b/src/HomeMaticCentral.cpp
@@ -1451,16 +1451,19 @@ std::string HomeMaticCentral::handleCliCommand(std::string command)
 					else if(filterType == "address")
 					{
 						int32_t address = BaseLib::Math::getNumber(filterValue, true);
-						if(i->second->getAddress() != address) continue;
+						std::string addressHex = BaseLib::HelperFunctions::getHexString(i->second->getAddress(), 6);
+						if((i->second->getAddress() != address) && ((signed)BaseLib::HelperFunctions::toLower(addressHex).find(filterValue) == (signed)std::string::npos)) continue;
 					}
 					else if(filterType == "serial")
 					{
-						if(i->second->getSerialNumber() != filterValue) continue;
+						std::string serial = i->second->getSerialNumber();
+						if((signed)BaseLib::HelperFunctions::toLower(serial).find(filterValue) == (signed)std::string::npos) continue;
 					}
 					else if(filterType == "type")
 					{
 						int32_t deviceType = BaseLib::Math::getNumber(filterValue, true);
-						if((int32_t)i->second->getDeviceType() != deviceType) continue;
+						std::string deviceTypeHex = BaseLib::HelperFunctions::getHexString(i->second->getDeviceType(), 4);
+						if(((int32_t)i->second->getDeviceType() != deviceType) && ((signed)BaseLib::HelperFunctions::toLower(deviceTypeHex).find(filterValue) == (signed)std::string::npos)) continue;
 					}
 					else if(filterType == "configpending")
 					{


### PR DESCRIPTION
This should fix the problem, that searching for a serial number does not work (serial number was converted to lower case and then compared to the original upper case value).
Searching for Address or Type also didn't work as expected, because it was searched for the decimal representation and not the displayed hex-representation.
My suggestion is to compare against both (if a script uses the decimal or a user the hex value)

Greets and thanks
Patrick