### PR TITLE
Fix for HM-LC-RGBW-WM

### DIFF
--- a/misc/Device Description Files/rf_rgbw.xml
+++ b/misc/Device Description Files/rf_rgbw.xml
@@ -1,7 +1,7 @@
-<homegearDevice version="41">
+<homegearDevice version="44">
 	<supportedDevices>
 		<device id="HM-LC-RGBW-WM">
-			<description>Wireless RGBW Controller for wall mounting</description>
+			<description>Wireless RGB+W Controller for wall mounting</description>
 			<typeNumber>0xF4</typeNumber>
 			<minFirmwareVersion>0x10</minFirmwareVersion>
 		</device>
@@ -14,7 +14,7 @@
 			<properties>
 				<internal>true</internal>
 			</properties>
-			<configParameters>switch_dev_master--0</configParameters>
+			<configParameters>dimmer_dev_master--0</configParameters>
 			<variables>maint_ch_values--0</variables>
 		</function>
 		<function channel="1" type="DIMMER">
@@ -355,6 +355,70 @@
 		</packet>
 	</packets>
 	<parameterGroups>
+		<configParameters id="dimmer_dev_master--0">
+			<parameter id="INTERNAL_KEYS_VISIBLE">
+				<properties>
+					<internal>true</internal>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger>
+					<index>2.7</index>
+					<size>0.1</size>
+					<list>0</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="LOCAL_RESET_DISABLE">
+				<properties/>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger>
+					<index>24.0</index>
+					<size>1.0</size>
+					<list>0</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="ROAMING">
+				<properties>
+					<internal>true</internal>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger>
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="POLLING">
+				<properties>
+					<internal>true</internal>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger>
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="POLLING_INTERVAL">
+				<properties>
+					<internal>true</internal>
+					<unit>min</unit>
+				</properties>
+				<logicalInteger>
+					<minimumValue>10</minimumValue>
+					<maximumValue>1440</maximumValue>
+					<defaultValue>60</defaultValue>
+				</logicalInteger>
+				<physicalInteger>
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+		</configParameters>
 		<configParameters id="dimmer_ch_master--1">
 			<parameter id="AES_ACTIVE">
 				<properties>
@@ -372,41 +436,240 @@
 					<operationType>config</operationType>
 				</physicalInteger>
 			</parameter>
-		</configParameters>
-		<configParameters id="rgbw_automatic_ch_master--3">
-			<parameter id="COLOR_CHANGE_SPEED">
-				<properties>
-					<unit>s/U</unit>
-				</properties>
+			<parameter id="TRANSMIT_TRY_MAX">
+				<properties/>
 				<logicalInteger>
 					<minimumValue>0</minimumValue>
-					<maximumValue>255</maximumValue>
-					<defaultValue>10</defaultValue>
+					<maximumValue>10</maximumValue>
+					<defaultValue>6</defaultValue>
 				</logicalInteger>
 				<physicalInteger>
-					<index>167.0</index>
+					<index>48.0</index>
 					<size>1.0</size>
 					<list>1</list>
 					<operationType>config</operationType>
 				</physicalInteger>
 			</parameter>
-			<parameter id="AES_ACTIVE">
+			<parameter id="REDUCE_TEMP_LEVEL">
 				<properties>
-					<internal>true</internal>
-					<casts>
-						<booleanInteger/>
-					</casts>
+					<unit>°C</unit>
 				</properties>
-				<logicalBoolean>
-					<defaultValue>false</defaultValue>
-				</logicalBoolean>
-				<physicalInteger groupId="AES_ACTIVE">
-					<index>8.0</index>
+				<logicalInteger>
+					<minimumValue>30</minimumValue>
+					<maximumValue>100</maximumValue>
+					<defaultValue>75</defaultValue>
+				</logicalInteger>
+				<physicalInteger>
+					<index>52.0</index>
+					<size>1.0</size>
 					<list>1</list>
 					<operationType>config</operationType>
 				</physicalInteger>
 			</parameter>
-		</configParameters>
+			<parameter id="REDUCE_LEVEL">
+				<properties>
+					<unit>100%</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>200.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>1.000000</maximumValue>
+					<defaultValue>0.400000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger>
+					<index>53.0</index>
+					<size>1.0</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="OVERTEMP_LEVEL">
+				<properties>
+					<unit>°C</unit>
+				</properties>
+				<logicalInteger>
+					<minimumValue>30</minimumValue>
+					<maximumValue>100</maximumValue>
+					<defaultValue>80</defaultValue>
+				</logicalInteger>
+				<physicalInteger>
+					<index>50.0</index>
+					<size>1.0</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="FUSE_DELAY">
+				<properties>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>100.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>2.550000</maximumValue>
+					<defaultValue>1.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger>
+					<index>51.0</index>
+					<size>1.0</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="POWERUP_ACTION">
+				<properties/>
+				<logicalEnumeration>
+					<defaultValue>0</defaultValue>
+					<value>
+						<id>POWERUP_OFF</id>
+						<index>0</index>
+					</value>
+					<value>
+						<id>POWERUP_ON</id>
+						<index>1</index>
+					</value>
+				</logicalEnumeration>
+				<physicalInteger>
+					<index>86.0</index>
+					<size>0.1</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="STATUSINFO_MINDELAY">
+				<properties>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>2.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.500000</minimumValue>
+					<maximumValue>15.500000</maximumValue>
+					<defaultValue>2.000000</defaultValue>
+					<specialValues>
+						<specialValue id="NOT_USED">0.000000</specialValue>
+					</specialValues>
+				</logicalDecimal>
+				<physicalInteger>
+					<index>87.0</index>
+					<size>0.5</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="STATUSINFO_RANDOM">
+				<properties>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>1.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>7.000000</maximumValue>
+					<defaultValue>1.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger>
+					<index>87.5</index>
+					<size>0.3</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="LOGIC_COMBINATION">
+				<properties/>
+				<logicalEnumeration>
+					<defaultValue>1</defaultValue>
+					<value>
+						<id>LOGIC_INACTIVE</id>
+						<index>0</index>
+					</value>
+					<value>
+						<id>LOGIC_OR</id>
+						<index>1</index>
+					</value>
+					<value>
+						<id>LOGIC_AND</id>
+						<index>2</index>
+					</value>
+					<value>
+						<id>LOGIC_XOR</id>
+						<index>3</index>
+					</value>
+					<value>
+						<id>LOGIC_NOR</id>
+						<index>4</index>
+					</value>
+					<value>
+						<id>LOGIC_NAND</id>
+						<index>5</index>
+					</value>
+					<value>
+						<id>LOGIC_ORINVERS</id>
+						<index>6</index>
+					</value>
+					<value>
+						<id>LOGIC_ANDINVERS</id>
+						<index>7</index>
+					</value>
+					<value>
+						<id>LOGIC_PLUS</id>
+						<index>8</index>
+					</value>
+					<value>
+						<id>LOGIC_MINUS</id>
+						<index>9</index>
+					</value>
+					<value>
+						<id>LOGIC_MUL</id>
+						<index>10</index>
+					</value>
+					<value>
+						<id>LOGIC_PLUSINVERS</id>
+						<index>11</index>
+					</value>
+					<value>
+						<id>LOGIC_MINUSINVERS</id>
+						<index>12</index>
+					</value>
+					<value>
+						<id>LOGIC_MULINVERS</id>
+						<index>13</index>
+					</value>
+					<value>
+						<id>LOGIC_INVERSPLUS</id>
+						<index>14</index>
+					</value>
+					<value>
+						<id>LOGIC_INVERSMINUS</id>
+						<index>15</index>
+					</value>
+					<value>
+						<id>LOGIC_INVERSMUL</id>
+						<index>16</index>
+					</value>
+				</logicalEnumeration>
+				<physicalInteger>
+					<index>89.0</index>
+					<size>0.5</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>                  
+		</configParameters>     
 		<configParameters id="rgbw_color_ch_master--2">
 			<parameter id="WHITE_ADJUSTMENT_VALUE_RED">
 				<properties>
@@ -473,71 +736,40 @@
 				</physicalInteger>
 			</parameter>
 		</configParameters>
-		<configParameters id="switch_dev_master--0">
-			<parameter id="INTERNAL_KEYS_VISIBLE">
+		<configParameters id="rgbw_automatic_ch_master--3">
+			<parameter id="COLOR_CHANGE_SPEED">
 				<properties>
-					<internal>true</internal>
-				</properties>
-				<logicalBoolean>
-					<defaultValue>false</defaultValue>
-				</logicalBoolean>
-				<physicalInteger>
-					<index>2.7</index>
-					<size>0.1</size>
-					<list>0</list>
-					<operationType>config</operationType>
-				</physicalInteger>
-			</parameter>
-			<parameter id="LOCAL_RESET_DISABLE">
-				<properties/>
-				<logicalBoolean>
-					<defaultValue>false</defaultValue>
-				</logicalBoolean>
-				<physicalInteger>
-					<index>24.0</index>
-					<size>1.0</size>
-					<list>0</list>
-					<operationType>config</operationType>
-				</physicalInteger>
-			</parameter>
-			<parameter id="ROAMING">
-				<properties>
-					<internal>true</internal>
-				</properties>
-				<logicalBoolean>
-					<defaultValue>false</defaultValue>
-				</logicalBoolean>
-				<physicalInteger>
-					<operationType>store</operationType>
-				</physicalInteger>
-			</parameter>
-			<parameter id="POLLING">
-				<properties>
-					<internal>true</internal>
-				</properties>
-				<logicalBoolean>
-					<defaultValue>false</defaultValue>
-				</logicalBoolean>
-				<physicalInteger>
-					<operationType>store</operationType>
-				</physicalInteger>
-			</parameter>
-			<parameter id="POLLING_INTERVAL">
-				<properties>
-					<internal>true</internal>
-					<unit>min</unit>
+					<unit>s/U</unit>
 				</properties>
 				<logicalInteger>
-					<minimumValue>10</minimumValue>
-					<maximumValue>1440</maximumValue>
-					<defaultValue>60</defaultValue>
+					<minimumValue>0</minimumValue>
+					<maximumValue>255</maximumValue>
+					<defaultValue>10</defaultValue>
 				</logicalInteger>
 				<physicalInteger>
-					<operationType>store</operationType>
+					<index>167.0</index>
+					<size>1.0</size>
+					<list>1</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="AES_ACTIVE">
+				<properties>
+					<internal>true</internal>
+					<casts>
+						<booleanInteger/>
+					</casts>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="AES_ACTIVE">
+					<index>8.0</index>
+					<list>1</list>
+					<operationType>config</operationType>
 				</physicalInteger>
 			</parameter>
 		</configParameters>
-		<variables id="dimmer_ch_values--1"/>
 		<variables id="maint_ch_values--0">
 			<parameter id="UNREACH">
 				<properties>
@@ -662,6 +894,772 @@
 				</physicalInteger>
 			</parameter>
 		</variables>
+		<variables id="dimmer_ch_values--1">
+			<parameter id="LEVEL">
+				<properties>
+					<control>DIMMER.LEVEL</control>
+					<unit>100%</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>200.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>1.000000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="LEVEL">
+					<size>1.0</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="LEVEL_SET">
+						<type>set</type>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="OLD_LEVEL">
+				<properties>
+					<readable>false</readable>
+					<control>DIMMER.OLD_LEVEL</control>
+				</properties>
+				<logicalAction/>
+				<physicalInteger>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="OLD_LEVEL">
+						<type>set</type>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="LEVEL_REAL">
+				<properties>
+					<writeable>false</writeable>
+					<control>DIMMER.LEVEL_REAL</control>
+					<unit>100%</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>200.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>1.000000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="LEVEL_REAL">
+					<size>1.0</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="INFO_LEVEL_R">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS_R">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="RAMP_TIME">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>10.000000</factor>
+						</decimalIntegerScale>
+						<integerTinyFloat/>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>85825945.600000</maximumValue>
+					<defaultValue>0.500000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="RAMP_TIME">
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="ON_TIME">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>10.000000</factor>
+						</decimalIntegerScale>
+						<integerTinyFloat/>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>85825945.600000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="ON_TIME">
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="RAMP_STOP">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+				</properties>
+				<logicalAction/>
+				<physicalInteger>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="RAMP_STOP">
+						<type>set</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="INHIBIT">
+				<properties>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean/>
+				<physicalInteger groupId="INHIBIT">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="SET_LOCK">
+						<type>set</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="WORKING">
+				<properties>
+					<writeable>false</writeable>
+					<internal>true</internal>
+					<casts>
+						<booleanInteger/>
+						<integerIntegerMap>
+							<direction>both</direction>
+							<value>
+								<physical>0</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>1</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>2</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>3</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>4</physical>
+								<logical>1</logical>
+							</value>
+						</integerIntegerMap>
+					</casts>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="STATE_FLAGS">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="DIRECTION">
+				<properties>
+					<writeable>false</writeable>
+					<internal>true</internal>
+					<casts>
+						<optionInteger>
+							<value>
+								<physical>0</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>1</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>2</physical>
+								<logical>2</logical>
+							</value>
+							<value>
+								<physical>3</physical>
+								<logical>3</logical>
+							</value>
+						</optionInteger>
+					</casts>
+				</properties>
+				<logicalEnumeration>
+					<defaultValue>0</defaultValue>
+					<value>
+						<id>NONE</id>
+						<index>0</index>
+					</value>
+					<value>
+						<id>UP</id>
+						<index>1</index>
+					</value>
+					<value>
+						<id>DOWN</id>
+						<index>2</index>
+					</value>
+					<value>
+						<id>UNDEFINED</id>
+						<index>3</index>
+					</value>
+				</logicalEnumeration>
+				<physicalInteger groupId="DIRECTION_FLAGS">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_REDUCED">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_REDUCED">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_OVERLOAD">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_OVERLOAD">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_OVERHEAT">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_OVERHEAT">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="INSTALL_TEST">
+				<properties>
+					<readable>false</readable>
+					<internal>true</internal>
+					<casts>
+						<toggle>
+							<parameter>LEVEL</parameter>
+						</toggle>
+					</casts>
+				</properties>
+				<logicalAction/>
+				<physicalInteger groupId="TOGGLE_FLAG">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="TOGGLE_INSTALL_TEST">
+						<type>set</type>
+					</packet>
+				</packets>
+			</parameter>
+		</variables>
+		<variables id="rgbw_color_ch_values--2">
+			<parameter id="COLOR">
+				<properties>
+					<control>DIMMER.LEVEL</control>
+					<unit>100%</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>200.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>1.000000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="LEVEL">
+					<size>1.0</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="LEVEL_SET">
+						<type>set</type>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="OLD_COLOR">
+				<properties>
+					<readable>false</readable>
+					<control>DIMMER.OLD_LEVEL</control>
+				</properties>
+				<logicalAction/>
+				<physicalInteger>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="OLD_LEVEL">
+						<type>set</type>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="LEVEL_REAL">
+				<properties>
+					<writeable>false</writeable>
+					<control>DIMMER.LEVEL_REAL</control>
+					<unit>100%</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>200.000000</factor>
+						</decimalIntegerScale>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>1.000000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="LEVEL_REAL">
+					<size>1.0</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+						<autoReset>
+							<parameterId>RAMP_TIME</parameterId>
+							<parameterId>ON_TIME</parameterId>
+						</autoReset>
+					</packet>
+					<packet id="INFO_LEVEL_R">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS_R">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="RAMP_TIME">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>10.000000</factor>
+						</decimalIntegerScale>
+						<integerTinyFloat/>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>85825945.600000</maximumValue>
+					<defaultValue>0.500000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="RAMP_TIME">
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="ON_TIME">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+					<unit>s</unit>
+					<casts>
+						<decimalIntegerScale>
+							<factor>10.000000</factor>
+						</decimalIntegerScale>
+						<integerTinyFloat/>
+					</casts>
+				</properties>
+				<logicalDecimal>
+					<minimumValue>0.000000</minimumValue>
+					<maximumValue>85825945.600000</maximumValue>
+					<defaultValue>0.000000</defaultValue>
+				</logicalDecimal>
+				<physicalInteger groupId="ON_TIME">
+					<operationType>store</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="RAMP_STOP">
+				<properties>
+					<readable>false</readable>
+					<control>NONE</control>
+				</properties>
+				<logicalAction/>
+				<physicalInteger>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="RAMP_STOP">
+						<type>set</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="INHIBIT">
+				<properties>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean/>
+				<physicalInteger groupId="INHIBIT">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="SET_LOCK">
+						<type>set</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="WORKING">
+				<properties>
+					<writeable>false</writeable>
+					<internal>true</internal>
+					<casts>
+						<booleanInteger/>
+						<integerIntegerMap>
+							<direction>both</direction>
+							<value>
+								<physical>0</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>1</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>2</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>3</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>4</physical>
+								<logical>1</logical>
+							</value>
+						</integerIntegerMap>
+					</casts>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="STATE_FLAGS">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="DIRECTION">
+				<properties>
+					<writeable>false</writeable>
+					<internal>true</internal>
+					<casts>
+						<optionInteger>
+							<value>
+								<physical>0</physical>
+								<logical>0</logical>
+							</value>
+							<value>
+								<physical>1</physical>
+								<logical>1</logical>
+							</value>
+							<value>
+								<physical>2</physical>
+								<logical>2</logical>
+							</value>
+							<value>
+								<physical>3</physical>
+								<logical>3</logical>
+							</value>
+						</optionInteger>
+					</casts>
+				</properties>
+				<logicalEnumeration>
+					<defaultValue>0</defaultValue>
+					<value>
+						<id>NONE</id>
+						<index>0</index>
+					</value>
+					<value>
+						<id>UP</id>
+						<index>1</index>
+					</value>
+					<value>
+						<id>DOWN</id>
+						<index>2</index>
+					</value>
+					<value>
+						<id>UNDEFINED</id>
+						<index>3</index>
+					</value>
+				</logicalEnumeration>
+				<physicalInteger groupId="DIRECTION_FLAGS">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="LEVEL_GET">
+						<type>get</type>
+						<responseId>INFO_LEVEL</responseId>
+					</packet>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+					<packet id="INFO_POWERON">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_REDUCED">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_REDUCED">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_OVERLOAD">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_OVERLOAD">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="ERROR_OVERHEAT">
+				<properties>
+					<writeable>false</writeable>
+					<service>true</service>
+					<control>NONE</control>
+				</properties>
+				<logicalBoolean>
+					<defaultValue>false</defaultValue>
+				</logicalBoolean>
+				<physicalInteger groupId="ERROR_OVERHEAT">
+					<size>0.1</size>
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="INFO_LEVEL">
+						<type>event</type>
+					</packet>
+					<packet id="ACK_STATUS">
+						<type>event</type>
+					</packet>
+				</packets>
+			</parameter>
+			<parameter id="INSTALL_TEST">
+				<properties>
+					<readable>false</readable>
+					<internal>true</internal>
+					<casts>
+						<toggle>
+							<parameter>COLOR</parameter>
+						</toggle>
+					</casts>
+				</properties>
+				<logicalAction/>
+				<physicalInteger groupId="TOGGLE_FLAG">
+					<operationType>command</operationType>
+				</physicalInteger>
+				<packets>
+					<packet id="TOGGLE_INSTALL_TEST">
+						<type>set</type>
+					</packet>
+				</packets>
+			</parameter>
+		</variables>
 		<variables id="rgbw_automatic_ch_values--3">
 			<parameter id="USER_PROGRAM">
 				<properties>
@@ -670,18 +1668,6 @@
 				</properties>
 				<logicalString/>
 				<physicalString groupId="USER_PROGRAM">
-					<operationType>store</operationType>
-				</physicalString>
-			</parameter>
-		</variables>
-		<variables id="rgbw_color_ch_values--2">
-			<parameter id="USER_COLOR">
-				<properties>
-					<readable>false</readable>
-					<control>NONE</control>
-				</properties>
-				<logicalString/>
-				<physicalString groupId="USER_COLOR">
 					<operationType>store</operationType>
 				</physicalString>
 			</parameter>
@@ -2654,6 +3640,40 @@
 				<parameter id="LCD_LEVEL_INTERP">1</parameter>
 				<parameter id="LCD_SYMBOL">2</parameter>
 			</scenario>
+		</linkParameters>      
+		<linkParameters id="rgbw_color_ch_link--2">
+			<parameter id="SHORT_ACT_HSV_COLOR_VALUE">
+				<properties/>
+				<logicalInteger>
+					<minimumValue>0</minimumValue>
+					<maximumValue>255</maximumValue>
+					<defaultValue>0</defaultValue>
+				</logicalInteger>
+				<physicalInteger>
+					<index>47.0</index>
+					<size>1.0</size>
+					<list>3</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<parameter id="LONG_ACT_HSV_COLOR_VALUE">
+				<properties/>
+				<logicalInteger>
+					<minimumValue>0</minimumValue>
+					<maximumValue>255</maximumValue>
+					<defaultValue>0</defaultValue>
+				</logicalInteger>
+				<physicalInteger>
+					<index>175.0</index>
+					<size>1.0</size>
+					<list>3</list>
+					<operationType>config</operationType>
+				</physicalInteger>
+			</parameter>
+			<scenario id="default">
+				<parameter id="LCD_LEVEL_INTERP">1</parameter>
+				<parameter id="LCD_SYMBOL">2</parameter>
+			</scenario>
 		</linkParameters>
 		<linkParameters id="rgbw_automatic_ch_link--3">
 			<parameter id="SHORT_ACT_COLOR_PROGRAM">
@@ -2745,40 +3765,5 @@
 				<parameter id="LCD_SYMBOL">2</parameter>
 			</scenario>
 		</linkParameters>
-		<linkParameters id="rgbw_color_ch_link--2">
-			<parameter id="SHORT_ACT_HSV_COLOR_VALUE">
-				<properties/>
-				<logicalInteger>
-					<minimumValue>0</minimumValue>
-					<maximumValue>255</maximumValue>
-					<defaultValue>0</defaultValue>
-				</logicalInteger>
-				<physicalInteger>
-					<index>47.0</index>
-					<size>1.0</size>
-					<list>3</list>
-					<operationType>config</operationType>
-				</physicalInteger>
-			</parameter>
-			<parameter id="LONG_ACT_HSV_COLOR_VALUE">
-				<properties/>
-				<logicalInteger>
-					<minimumValue>0</minimumValue>
-					<maximumValue>255</maximumValue>
-					<defaultValue>0</defaultValue>
-				</logicalInteger>
-				<physicalInteger>
-					<index>175.0</index>
-					<size>1.0</size>
-					<list>3</list>
-					<operationType>config</operationType>
-				</physicalInteger>
-			</parameter>
-			<scenario id="default">
-				<parameter id="LCD_LEVEL_INTERP">1</parameter>
-				<parameter id="LCD_SYMBOL">2</parameter>
-			</scenario>
-		</linkParameters>
-	</parameterGroups>
+    </parameterGroups>
 </homegearDevice>
-


### PR DESCRIPTION
Hi,

the current configuration for HM-LC-RGBW-WM does not seem work with Homegear and Home Assistant. 

Because I want to use such a device, I picked the up the configuration XML from here:

https://forum.homegear.eu/t/variablen-für-openhab-von-hm-lc-rgbw-wm/976

Dimming and basic color change works now in Homegear, but color change in HA does not. Maybe there is still some work to do in the XML, but I think for others it would be great to have this working out of the box...
