### PR TITLE
Fixed Channel 2 IEC_ENERGY_METER (physicalInteger)

### DIFF
--- a/misc/Device Description Files/rf_es_tx_wm.xml
+++ b/misc/Device Description Files/rf_es_tx_wm.xml
@@ -1111,15 +1111,20 @@
 					<writeable>false</writeable>
 					<control>POWERMETER_IEC2.IEC_ENERGY_COUNTER</control>
 					<unit>kWh</unit>
+					<casts>
+                                                <decimalIntegerScale>
+                                                        <factor>10000.000000</factor>
+                                                </decimalIntegerScale>
+                                        </casts>
 				</properties>
 				<logicalDecimal>
 					<minimumValue>0.000000</minimumValue>
 					<maximumValue>109951162.777500</maximumValue>
 				</logicalDecimal>
-				<physicalString groupId="IEC_ENERGY_COUNTER">
+				<physicalInteger groupId="IEC_ENERGY_COUNTER">
 					<size>5.0</size>
 					<operationType>command</operationType>
-				</physicalString>
+				</physicalInteger>
 				<packets>
 					<packet id="IEC_POWER_EVENT_CYCLIC">
 						<type>event</type>


### PR DESCRIPTION
Fixes for channel 1 were already made, but not for channel 2:
https://forum.homegear.eu/t/firmware-update-von-hm-es-tx-wm-funktioniert-nicht/670/28