### PR TITLE
Removed min/maxValue for IEC_POWER

### DIFF
--- a/misc/Device Description Files/rf_es_tx_wm.xml
+++ b/misc/Device Description Files/rf_es_tx_wm.xml
@@ -1087,10 +1087,6 @@
 						</decimalIntegerScale>
 					</casts>
 				</properties>
-				<logicalDecimal>
-					<minimumValue>0.000000</minimumValue>
-					<maximumValue>42949672.950000</maximumValue>
-				</logicalDecimal>
 				<physicalInteger groupId="IEC_POWER">
 					<size>4.0</size>
 					<operationType>command</operationType>


### PR DESCRIPTION
to support negative values for solar panel power generation.
https://forum.homegear.eu/t/hm-es-tx-wm-mit-es-iec-am-zweirichtungsz%C3%A4hler-%C3%BCbertr%C3%A4gt-f%C3%BCr-iecpower-keine-negativen-werte-einspeisung/3969/3